### PR TITLE
Lock google-api-client version to 0.8.x

### DIFF
--- a/ruboty-google_calendar.gemspec
+++ b/ruboty-google_calendar.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "google-api-client"
+  spec.add_runtime_dependency "google-api-client", "~> 0.8.7"
   spec.add_runtime_dependency "ruboty"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
As breaking changes were introduced in the 0.9, we need to lock the version to 0.8.x.
Otherwise, we need to fix a lot more codes to get this working on latest version. Any thoughts?

> Code written against the 0.8.x version of this library will not work with the 0.9 version without modification.
> [google\-api\-ruby\-client/MIGRATING\.md at master · google/google\-api\-ruby\-client](https://github.com/google/google-api-ruby-client/blob/master/MIGRATING.md#migrating-from-version-08x-to-09-or-above)